### PR TITLE
Added the missing handler for the REST service supposed to translate the category groups (currently returning error 500)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "catalog-translations-rest",
   "vendor": "vtex",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "Catalog Translations REST",
   "description": "REST Api for catalog translations",
   "mustUpdateAt": "2018-01-04",

--- a/node/clients/catalogClient/queries/index.ts
+++ b/node/clients/catalogClient/queries/index.ts
@@ -26,7 +26,7 @@ export const SKU_PRODUCT_SPCIFICATION_TRANSLATION_MUTATION = `
 `
 
 export const SPECIFICATION_VALUES_TRANSLATION_MUTATION = `
-  mutation($args: FieldValueInputTranslation, $locale: Locale){
+  mutation translate($args: FieldValueInputTranslation, $locale: Locale){
     translateFieldValues(fieldValues: $args, locale: $locale)
   }
 `

--- a/node/clients/catalogClient/queries/index.ts
+++ b/node/clients/catalogClient/queries/index.ts
@@ -26,8 +26,8 @@ export const SKU_PRODUCT_SPCIFICATION_TRANSLATION_MUTATION = `
 `
 
 export const SPECIFICATION_VALUES_TRANSLATION_MUTATION = `
-  mutation translate($args:FieldValueInputTranslation, $locale:Locale){
-    translateFieldValues(fieldValues:$args,locale:$locale)
+  mutation($args: FieldValueInputTranslation, $locale: Locale){
+    translateFieldValues(fieldValues: $args, locale: $locale)
   }
 `
 

--- a/node/index.ts
+++ b/node/index.ts
@@ -13,6 +13,7 @@ import {
   validateBulkBody,
   sendEmail,
   validateAuthToken,
+  categoryGroupTranslation,
 } from './middlewares'
 import { createEmailTemplate } from './events/createEmailTemplate'
 
@@ -60,6 +61,9 @@ export default new Service({
     }),
     categoryTranslation: method({
       POST: [validateAuthToken, categoryTranslation],
+    }),
+    categoryGroupTranslation: method({
+      POST: [validateAuthToken, categoryGroupTranslation],
     }),
     brandTranslation: method({
       POST: [validateAuthToken, brandTranslation],


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adding the missing handler for the REST service supposed to translate the category groups (POST /v0/catalog-translation/category-group)

#### What problem is this solving?

Solving the error "Handler with id 'categoryGroupTranslation' not implemented" (status code: 500) the REST service /v0/catalog-translation/category-group returns currently.

#### How to test it?

pull request ref: https://github.com/lucablasi-reply/catalog-translations-rest/tree/fix/missing-handler-for-category-group-translation
