### PR TITLE
added 1 method to translate the product specifications of type 'free text' + 7 methods to retrieve the catalog translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2022-10-12
+### Added
+- route to translate product specifications of type "free text"
+- route to retrieve translations for specific category and locale
+- route to retrieve translations for specific category group and locale
+- route to retrieve translations for specific specification field and locale
+- route to retrieve translations for specific specification value and locale
+- route to retrieve translations for specific brand and locale
+- route to retrieve translations for specific product and locale
+- route to retrieve translations for specific sku and locale 
 
 ## [1.0.2] - 2022-09-01
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,12 @@
 # Catalog Translations Rest
 
-Rest API that allows both the translation of each entity of the catalog in particular, as well as the massive translation of them.
+Rest API that allows to define / retrieve translations for each entity of the catalog. The definition of translations can be performed also massively by using the route "Bulk".
 
-You can download the Postman Collection from this ([link](https://github.com/vtex-apps/catalog-translations-rest/blob/development/docs/VTEX%20-%20Catalog%20Translation%20API.postman_collection.json)).
+You can download an example of Postman Collection from this ([link](https://github.com/vtex-apps/catalog-translations-rest/blob/development/docs/VTEX%20-%20Catalog%20Translation%20API.postman_collection.json)).
 
 Check ([this](https://developers.vtex.com/vtex-developer-docs/docs/catalog-internationalization)) documentation for more information.
 
-## Routes
-
-### Authentication
+## Authentication
 
 Each route must include in the headers either:
 
@@ -23,23 +21,9 @@ Or:
 | -------------------- | -------- | ----------------------------------- |
 | `authorizationToken` | string   | VTEX Auth Cookie for authorization. |
 
-Every translation entity must have this two properties:
+Following you can find the list of available routes.
 
-| **Property** | **Type** | **Description**                                  |
-| ------------ | -------- | ------------------------------------------------ |
-| `args`       | object   | Translation information for the specific entity. |
-| `locale`     | string   | Translation language (ex: 'fr-FR').              |
-
-Example:
-
-```json
-    {
-        "args": {
-          {...}
-        },
-        "name": "{locale}"
-    }
-```
+## Translation Definition
 
 #### Category
 
@@ -47,14 +31,7 @@ Example:
 
 `https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/category`
 
-| **args**    | **Type** |
-| ----------- | -------- |
-| id          | string   |
-| name        | string   |
-| title       | string   |
-| description | string   |
-| keywords    | [string] |
-| linkId      | string   |
+Payload example:
 
 ```json
 {
@@ -70,19 +47,100 @@ Example:
 }
 ```
 
+#### Category Group
+
+`POST`
+
+`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/category-group`
+
+Payload example:
+
+```json
+{
+    "args": {
+        "groupId": "1794",
+        "name": "Performance"
+    },
+    "locale": "en-US"
+}
+```
+
+#### Specification Field
+
+`POST`
+
+`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/sku-specification`
+
+Payload example:
+
+```json
+{
+  "args": {
+    "fieldId": "31",
+    "name": "Cor"
+  },
+  "locale": "pt-BR"
+}
+```
+
+#### Specification Values
+
+`POST`
+
+`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/specification-values`
+
+Payload example:
+
+```json
+{
+  "args": {
+    "fieldId": "31",
+    "fieldValuesNames": [
+      {
+        "id": "91",
+        "name": "Azul"
+      },
+      {
+        "id": "92",
+        "name": "Vermelho"
+      }
+    ]
+  },
+  "locale": "pt-BR"
+}
+```
+
+#### Product Specification (type: free text)
+
+`POST`
+
+`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/product-specification`
+
+Payload example:
+
+```json
+{
+  "args": {
+    "to": "en-US",
+    "messages": [
+      {
+        "srcLang": "it-IT",
+        "srcMessage": "A libera installazione",
+        "targetMessage": "Free standing",
+        "context": "5086"
+      }
+    ] 
+  }
+}
+```
+
 #### Brand
 
 `POST`
 
 `https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/brand`
 
-| **args**  | **Type** |
-| --------- | -------- |
-| id        | object   |
-| name      | string   |
-| text      | string   |
-| siteTitle | string   |
-| keywords  | string   |
+Payload example:
 
 ```json
 {
@@ -103,16 +161,7 @@ Example:
 
 `https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/product`
 
-| **args**           | **Type** |
-| ------------------ | -------- |
-| id                 | string   |
-| name               | string   |
-| title              | string   |
-| description        | string   |
-| shortDescription   | string   |
-| keywords           | [string] |
-| metaTagDescription | string   |
-| linkId             | string   |
+Payload example:
 
 ```json
 {
@@ -136,10 +185,7 @@ Example:
 
 `https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/sku`
 
-| **args** | **Type** |
-| -------- | -------- |
-| id       | string   |
-| name     | string   |
+Payload example:
 
 ```json
 {
@@ -150,68 +196,6 @@ Example:
   "locale": "pt-BR"
 }
 ```
-
-#### Sku or Product Specification
-
-`POST`
-
-`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/sku-specification`
-
-| **args** | **Type** |
-| -------- | -------- |
-| id       | string   |
-| name     | string   |
-
-```json
-{
-  "args": {
-    "fieldId": "31",
-    "name": "Cor"
-  },
-  "locale": "pt-BR"
-}
-```
-
-#### Specification Values
-
-`POST`
-
-`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/specification-values`
-
-| **args**        | **Type**                           |
-| --------------- | ---------------------------------- |
-| fieldId         | string                             |
-| fieldValueNames | [{ id: `string`, name: `string` }] |
-
-```json
-{
-  "args": {
-    "fieldId": "31",
-    "fieldValuesNames": [
-      {
-        "id": "91",
-        "name": "Azul"
-      },
-      {
-        "id": "92",
-        "name": "Vermelho"
-      }
-    ]
-  },
-  "locale": "pt-BR"
-}
-```
-
-#### Category Group
-
-`POST`
-
-`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/category-group`
-
-| **args** | **Type** |
-| -------- | -------- |
-| groupid  | string   |
-| name     | string   |
 
 #### Bulk Translate
 
@@ -233,5 +217,125 @@ It is necessary to specify an email where you will receive a report on the trans
   "skusProductsSpecifications": [],
   "specificationValuesData": [],
   "categoriesGroupsData": []
+}
+```
+
+## Translation Retrieval
+
+#### Category
+
+`POST`
+
+`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/category/fetch`
+
+Payload example:|
+
+```json
+{
+  "id": "12",
+  "srcLocale": "it-IT",
+  "dstLocale": "en-US"
+}
+```
+
+#### Category Group
+
+`POST`
+
+`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/category-group/fetch`
+
+Payload example::
+
+```json
+{
+  "id": "1794",
+  "srcLocale": "it-IT",
+  "dstLocale": "en-US"
+}
+```
+
+#### Specification Field
+
+`POST`
+
+`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/sku-specification/fetch`
+
+Payload example:
+
+```json
+{
+  "id": "5086",
+  "srcLocale": "it-IT",
+  "dstLocale": "en-US"
+}
+```
+
+#### Specification Values
+
+`POST`
+
+`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/specification-values/fetch`
+
+Payload example:
+
+```json
+{
+  "fieldId": "4113",
+  "srcLocale": "it-IT",
+  "dstLocale": "en-US"
+}
+```
+
+#### Brand
+
+`POST`
+
+`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/brand/fetch`
+
+Payload example:
+
+```json
+{
+  "id": "2000000",
+  "srcLocale": "it-IT",
+  "dstLocale": "en-US"
+}
+```
+
+#### Product
+
+`POST`
+
+`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/product/fetch`
+
+Payload example:
+
+```json
+{
+  "identifier": {
+    "field": "id",
+    "value": "12"
+  },
+  "srcLocale": "it-IT",
+  "dstLocale": "en-US"
+}
+```
+
+#### Sku
+
+`POST`
+
+`https://{environment}--{accountName}.myvtex.com/v0/catalog-translation/sku/fetch`
+
+Payload example:
+
+```json
+{
+  "identifier": {
+    "field": "id",
+    "value": "25"
+  },
+  "srcLocale": "it-IT",
+  "dstLocale": "en-US"
 }
 ```

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "catalog-translations-rest",
   "vendor": "vtex",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "title": "Catalog Translations REST",
   "description": "REST Api for catalog translations",
   "mustUpdateAt": "2018-01-04",
@@ -9,7 +9,8 @@
   "dependencies": {
     "vtex.catalog-graphql": "1.x",
     "vtex.file-manager-graphql": "0.x",
-    "vtex.file-manager": "0.x"
+    "vtex.file-manager": "0.x",
+    "vtex.messages": "1.x"
   },
   "builders": {
     "node": "6.x",
@@ -44,6 +45,9 @@
     },
     {
       "name": "vtex.catalog-graphql:resolve-graphql"
+    },
+    {
+      "name": "vtex.messages:graphql-save-translation-messages"
     },
     {
       "name": "outbound-access",

--- a/node/clients/catalogClient/index.ts
+++ b/node/clients/catalogClient/index.ts
@@ -14,6 +14,13 @@ import {
   SKU_PRODUCT_SPCIFICATION_TRANSLATION_MUTATION,
   SPECIFICATION_VALUES_TRANSLATION_MUTATION,
   CATEGORY_GROUP_TRANSLATION_MUTATION,
+  GET_PRODUCT_TRANSLATION_QUERY,
+  GET_CATEGORY_TRANSLATION_QUERY,
+  GET_CATEGORY_GROUP_TRANSLATION_QUERY,
+  SKU_TRANSLATION_QUERY,
+  BRAND_TRANSLATION_QUERY,
+  SKU_PRODUCT_SPCIFICATION_TRANSLATION_QUERY,
+  SPECIFICATION_VALUES_TRANSLATION_QUERY,
 } from './queries'
 
 class CustomGraphQLError extends Error {
@@ -56,6 +63,7 @@ export class CatalogGraphQL extends AppGraphQLClient {
       | SKUProductSpecificationData
       | SpecificationValuesData
       | CategoryGroupData
+      | ProductSpecificationPayload
   ): Promise<GraphQLResponse<Serializable>> => {
     return (
       this.graphql
@@ -80,21 +88,72 @@ export class CatalogGraphQL extends AppGraphQLClient {
     )
   }
 
+  private translationQuery = async (
+    authToken: string,
+    query: string,
+    variables:
+      | CategoryQueryPayload
+      | CategoryGroupQueryPayload
+      | FieldQueryPayload
+      | FieldValuesQueryPayload
+      | BrandQueryPayload
+      | ProductQueryPayload
+      | SkuQueryPayload,
+  ): Promise<GraphQLResponse<Serializable>> => {
+    this.options!.headers = {
+      ...this.options?.headers,
+      ...{
+        VtexIdclientAutCookie: authToken,
+        "x-vtex-tenant": variables.srcLocale,
+        "x-vtex-locale": variables.dstLocale
+      }
+    }
+    return this.graphql
+        .query<GraphQLResponse<Serializable>, TranslationQueryPayload>(
+          {
+            query: query,
+            variables,
+          },
+          this.options
+        )
+        .then(
+          throwOnGraphQLErrors('Error fetching data from vtex.catalog-graphql')
+        )
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        .then((query) => {
+          return query
+        })
+  }
+
   public categoryTranslation = async (
     authToken: string,
     categoryData: TranslatableData
-  ): Promise<any> =>
+  ): Promise<GraphQLResponse<Serializable>> =>
     this.translationMutation(
       authToken,
       CATEGORY_TRANSLATIONS_MUTATION,
       categoryData
     )
 
+  public categoryGroupTranslation = async (
+    authToken: string,
+    categoryGroupData: TranslatableData
+  ): Promise<GraphQLResponse<Serializable>> =>
+    this.translationMutation(
+      authToken,
+      CATEGORY_GROUP_TRANSLATION_MUTATION,
+      categoryGroupData
+    )
+
   public brandTranslation = async (
     authToken: string,
     brandData: TranslatableData
   ): Promise<GraphQLResponse<Serializable>> =>
-    this.translationMutation(authToken, BRAND_TRANSLATION_MUTATION, brandData)
+    this.translationMutation(
+      authToken,
+      BRAND_TRANSLATION_MUTATION,
+      brandData
+    )
 
   public productTranslation = async (
     authToken: string,
@@ -110,7 +169,11 @@ export class CatalogGraphQL extends AppGraphQLClient {
     authToken: string,
     skuData: TranslatableData
   ): Promise<GraphQLResponse<Serializable>> =>
-    this.translationMutation(authToken, SKU_TRANSLATION_MUTATION, skuData)
+    this.translationMutation(
+      authToken,
+      SKU_TRANSLATION_MUTATION,
+      skuData
+    )
 
   public skuProductSpecificationTranslation = async (
     authToken: string,
@@ -132,13 +195,73 @@ export class CatalogGraphQL extends AppGraphQLClient {
       specificationData
     )
 
-  public categoryGroupTranslation = async (
+  public getCategoryTranslation = async (
     authToken: string,
-    categoryGroupData: TranslatableData
+    categoryData: CategoryQueryPayload
   ): Promise<GraphQLResponse<Serializable>> =>
-    this.translationMutation(
+    this.translationQuery(
       authToken,
-      CATEGORY_GROUP_TRANSLATION_MUTATION,
+      GET_CATEGORY_TRANSLATION_QUERY,
+      categoryData
+    )
+
+  public getCategoryGroupTranslation = async (
+    authToken: string,
+    categoryGroupData: CategoryGroupQueryPayload
+  ): Promise<GraphQLResponse<Serializable>> =>
+    this.translationQuery(
+      authToken,
+      GET_CATEGORY_GROUP_TRANSLATION_QUERY,
       categoryGroupData
+    )
+
+  public getBrandTranslation = async (
+    authToken: string,
+    brandData: BrandQueryPayload
+  ): Promise<GraphQLResponse<Serializable>> =>
+    this.translationQuery(
+      authToken,
+      BRAND_TRANSLATION_QUERY,
+      brandData
+    )
+
+  public getProductTranslation = async (
+    authToken: string,
+    productData: ProductQueryPayload
+  ): Promise<GraphQLResponse<Serializable>> =>
+    this.translationQuery(
+      authToken,
+      GET_PRODUCT_TRANSLATION_QUERY,
+      productData
+    )
+
+  public getSkuTranslation = async (
+    authToken: string,
+    skuData: SkuQueryPayload
+  ): Promise<GraphQLResponse<Serializable>> =>
+    this.translationQuery(
+      authToken,
+      SKU_TRANSLATION_QUERY,
+      skuData
+    )
+
+  public getSkuProductSpecificationTranslation = async (
+    authToken: string,
+    specificationData: FieldQueryPayload
+  ): Promise<GraphQLResponse<Serializable>> =>
+    this.translationQuery(
+      authToken,
+      SKU_PRODUCT_SPCIFICATION_TRANSLATION_QUERY,
+      specificationData
+    )
+
+  public getSpecificationValuesTranslation = async (
+    authToken: string,
+    specificationData: FieldValuesQueryPayload
+  ): Promise<GraphQLResponse<Serializable>> =>
+    this.translationQuery(
+      authToken,
+      SPECIFICATION_VALUES_TRANSLATION_QUERY,
+      specificationData
     )
 }

--- a/node/clients/catalogClient/queries/index.ts
+++ b/node/clients/catalogClient/queries/index.ts
@@ -36,3 +36,90 @@ export const CATEGORY_GROUP_TRANSLATION_MUTATION = `
     translateGroup(group: $args, locale:$locale)
   }
 `
+
+export const GET_CATEGORY_TRANSLATION_QUERY = `
+  query getTranslation($id:ID!) {
+    category(id: $id) {
+      id
+      name
+      title
+      description
+      linkId
+      keywords
+    }
+  }
+`
+
+export const BRAND_TRANSLATION_QUERY = `
+  query getTranslation($id: ID!) {
+    brand(id: $id){
+      id
+      name
+      text
+      siteTitle
+      linkId
+    }
+  }
+`
+
+export const GET_PRODUCT_TRANSLATION_QUERY = `
+  query getTranslation($identifier: ProductUniqueIdentifier) {
+    product(identifier: $identifier) {
+      id
+      name
+      title
+      description
+      shortDescription
+      metaTagDescription
+      linkId
+      keywords
+    }
+  }
+`
+export const SKU_TRANSLATION_QUERY = `
+  query getTranslation($identifier: SKUUniqueIdentifier) {
+    sku(identifier: $identifier){
+      id
+      name
+      specifications{
+        product{
+          id
+          value
+          field{
+            fieldId
+            name
+            description
+          }
+        }
+      }
+    }
+  }
+`
+
+export const SKU_PRODUCT_SPCIFICATION_TRANSLATION_QUERY = `
+  query getTranslation($id: ID) {
+    field(id: $id){
+      fieldId
+      name
+    }
+  }
+`
+
+export const SPECIFICATION_VALUES_TRANSLATION_QUERY = `
+  query getTranslation($fieldId: ID) {
+    fieldValues(fieldId: $fieldId){
+      fieldValueId
+      value
+      text
+    }
+  }
+`
+
+export const GET_CATEGORY_GROUP_TRANSLATION_QUERY = `
+  query getTranslation($id: ID) {
+    group(id: $id){
+      id
+      name
+    }
+  }
+`

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -4,6 +4,7 @@ import { CatalogGraphQL } from './catalogClient'
 import { MessageCenter } from './messageCenter'
 import { FileManager } from './fileManager'
 import { AuthClient } from './authClient'
+import { MessagesClient } from './messagesClient'
 
 // Extend the default IOClients implementation with our own custom clients.
 export class Clients extends IOClients {
@@ -21,5 +22,8 @@ export class Clients extends IOClients {
 
   public get authClient() {
     return this.getOrSet('authClient', AuthClient)
+  }
+  public get messagesClient() {
+    return this.getOrSet('messagesClients', MessagesClient)
   }
 }

--- a/node/clients/messagesClient/index.ts
+++ b/node/clients/messagesClient/index.ts
@@ -1,0 +1,79 @@
+import { AppGraphQLClient, InstanceOptions, Serializable, GraphQLResponse, IOContext } from "@vtex/api";
+import { PRODUCT_SPECIFICATION_TRANSLATION_MUTATION } from "./query";
+
+class CustomGraphQLError extends Error {
+
+  public graphQLErrors: any
+
+  constructor(message: string, graphQLErrors: any[]) {
+    super(message)
+    this.graphQLErrors = graphQLErrors
+  }
+}
+
+function throwOnGraphQLErrors<T extends Serializable>(message: string) {
+  return function maybeGraphQLResponse(response: GraphQLResponse<T>) {
+    if (response?.errors && response.errors.length > 0) {
+      throw new CustomGraphQLError(message, response.errors)
+    }
+    return response
+  }
+}
+
+export class MessagesClient extends AppGraphQLClient {
+
+  constructor(ctx: IOContext, opts?: InstanceOptions){
+    super('vtex.messages@1.x', ctx, {
+      ...opts,
+      headers: {
+        ...opts?.headers
+      }
+    })
+  }
+
+  private translationMutation = async (
+    authToken: string,
+    query: string,
+    variables:
+      | CategoryTranslationData
+      | BrandData
+      | ProductData
+      | SKUData
+      | SKUProductSpecificationData
+      | SpecificationValuesData
+      | CategoryGroupData
+      | ProductSpecificationPayload
+  ): Promise<GraphQLResponse<Serializable>> => {
+    return (
+      this.graphql
+        .mutate(
+          {
+            mutate: query,
+            variables,
+          },
+          {
+            headers: {
+              VtexIdclientAutCookie: authToken,
+            },
+          }
+        )
+        .then(
+          throwOnGraphQLErrors('Error updating data from vtex.messages')
+        )
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        .then((query) => {
+          return query
+        })
+    )
+  }
+
+  public productSpecificationTranslation = (
+    authToken: string,
+    productSpecificationData: TranslatableData
+  ): Promise<GraphQLResponse<Serializable>> =>
+    this.translationMutation(
+      authToken,
+      PRODUCT_SPECIFICATION_TRANSLATION_MUTATION,
+      productSpecificationData
+    )
+}

--- a/node/clients/messagesClient/query/index.ts
+++ b/node/clients/messagesClient/query/index.ts
@@ -1,0 +1,5 @@
+export const PRODUCT_SPECIFICATION_TRANSLATION_MUTATION = `
+  mutation translate($args: SaveArgsV2!){
+    saveV2(args: $args)
+  }
+`

--- a/node/index.ts
+++ b/node/index.ts
@@ -14,6 +14,14 @@ import {
   sendEmail,
   validateAuthToken,
   categoryGroupTranslation,
+  productSpecificationTranslation,
+  getProductTranslation,
+  getCategoryTranslation,
+  getCategoryGroupTranslation,
+  getBrandTranslation,
+  getSkuTranslation,
+  getSkuProductSpecificationTranslation,
+  getSpecificationValuesTranslation,
 } from './middlewares'
 import { createEmailTemplate } from './events/createEmailTemplate'
 
@@ -45,7 +53,7 @@ declare global {
     bulkTranslationData: BulkTranslationData
     notificationEmail: string | undefined
     translationResponse: TranslationsDataResponse
-    translationData: TranslatableData
+    translationData: unknown
   }
 }
 
@@ -79,6 +87,30 @@ export default new Service({
     }),
     specificationValuesTranslation: method({
       POST: [validateAuthToken, specificationValuesTranslation],
+    }),
+    productSpecificationTranslation: method({
+      POST: [validateAuthToken, productSpecificationTranslation],
+    }),
+    getCategoryTranslation: method({
+      POST: [validateAuthToken, getCategoryTranslation],
+    }),
+    getCategoryGroupTranslation: method({
+      POST: [validateAuthToken, getCategoryGroupTranslation],
+    }),
+    getBrandTranslation: method({
+      POST: [validateAuthToken, getBrandTranslation],
+    }),
+    getProductTranslation: method({
+      POST: [validateAuthToken, getProductTranslation],
+    }),
+    getSkuTranslation: method({
+      POST: [validateAuthToken, getSkuTranslation],
+    }),
+    getSkuSpecificationTranslation: method({
+      POST: [validateAuthToken, getSkuProductSpecificationTranslation],
+    }),
+    getSpecificationValuesTranslation: method({
+      POST: [validateAuthToken, getSpecificationValuesTranslation],
     }),
   },
 })

--- a/node/middlewares/brand.ts
+++ b/node/middlewares/brand.ts
@@ -11,7 +11,29 @@ export async function brandTranslation(
 
   const response = await catalogGraphQl.brandTranslation(
     authorizationToken,
-    translationData
+    translationData as TranslatableData
+  )
+
+  ctx.status = 202
+  ctx.body = response
+
+  next()
+}
+
+export async function getBrandTranslation(
+  ctx: Context,
+  next: () => Promise<unknown>
+) {
+  const {
+    clients: { catalogGraphQl },
+    state,
+  } = ctx
+
+  const { authorizationToken, translationData } = state
+
+  const response = await catalogGraphQl.getBrandTranslation(
+    authorizationToken,
+    translationData as BrandQueryPayload
   )
 
   ctx.status = 202

--- a/node/middlewares/category.ts
+++ b/node/middlewares/category.ts
@@ -11,7 +11,7 @@ export async function categoryTranslation(
 
   const response = await catalogGraphQl.categoryTranslation(
     authorizationToken,
-    translationData
+    translationData as TranslatableData
   )
 
   ctx.status = 202
@@ -33,7 +33,51 @@ export async function categoryGroupTranslation(
 
   const response = await catalogGraphQl.categoryGroupTranslation(
     authorizationToken,
-    translationData
+    translationData as TranslatableData
+  )
+
+  ctx.status = 202
+  ctx.body = response
+
+  next()
+}
+
+export async function getCategoryTranslation(
+  ctx: Context,
+  next: () => Promise<unknown>
+) {
+  const {
+    clients: { catalogGraphQl },
+    state,
+  } = ctx
+
+  const { authorizationToken, translationData } = state
+
+  const response = await catalogGraphQl.getCategoryTranslation(
+    authorizationToken,
+    translationData as CategoryQueryPayload
+  )
+
+  ctx.status = 202
+  ctx.body = response
+
+  next()
+}
+
+export async function getCategoryGroupTranslation(
+  ctx: Context,
+  next: () => Promise<unknown>
+) {
+  const {
+    clients: { catalogGraphQl },
+    state,
+  } = ctx
+
+  const { authorizationToken, translationData } = state
+
+  const response = await catalogGraphQl.getCategoryGroupTranslation(
+    authorizationToken,
+    translationData as CategoryGroupQueryPayload
   )
 
   ctx.status = 202

--- a/node/middlewares/product.ts
+++ b/node/middlewares/product.ts
@@ -11,7 +11,7 @@ export async function productTranslation(
 
   const response = await catalogGraphQl.productTranslation(
     authorizationToken,
-    translationData
+    translationData as TranslatableData
   )
 
   ctx.status = 202
@@ -19,3 +19,25 @@ export async function productTranslation(
 
   next()
 }
+
+export async function getProductTranslation(
+  ctx: Context,
+  next: () => Promise<unknown>
+) {
+  const {
+    clients: { catalogGraphQl },
+    state,
+  } = ctx
+
+  const { authorizationToken, translationData } = state
+  const response = await catalogGraphQl.getProductTranslation(
+    authorizationToken,
+    translationData as ProductQueryPayload
+  )
+
+  ctx.status = 202
+  ctx.body = response
+
+  next()
+}
+

--- a/node/middlewares/sku.ts
+++ b/node/middlewares/sku.ts
@@ -11,7 +11,29 @@ export async function skuTranslation(
 
   const response = await catalogGraphQl.skuTranslation(
     authorizationToken,
-    translationData
+    translationData as TranslatableData
+  )
+
+  ctx.status = 202
+  ctx.body = response
+
+  next()
+}
+
+export async function getSkuTranslation(
+  ctx: Context,
+  next: () => Promise<unknown>
+) {
+  const {
+    clients: { catalogGraphQl },
+    state,
+  } = ctx
+
+  const { authorizationToken, translationData } = state
+
+  const response = await catalogGraphQl.getSkuTranslation(
+    authorizationToken,
+    translationData as SkuQueryPayload
   )
 
   ctx.status = 202

--- a/node/middlewares/specification.ts
+++ b/node/middlewares/specification.ts
@@ -11,7 +11,7 @@ export async function skuProductSpecificationTranslation(
 
   const response = await catalogGraphQl.skuProductSpecificationTranslation(
     authorizationToken,
-    translationData
+    translationData as TranslatableData
   )
 
   ctx.status = 202
@@ -33,7 +33,73 @@ export async function specificationValuesTranslation(
 
   const response = await catalogGraphQl.specificationValuesTranslation(
     authorizationToken,
-    translationData
+    translationData as TranslatableData
+  )
+
+  ctx.status = 202
+  ctx.body = response
+
+  next()
+}
+
+export async function productSpecificationTranslation(
+  ctx: Context,
+  next: () => Promise<unknown>
+){
+  const {
+    clients: { messagesClient },
+    state,
+  } = ctx
+
+  const { authorizationToken, translationData } = state
+
+  const response = await messagesClient.productSpecificationTranslation(
+    authorizationToken,
+    translationData as TranslatableData
+  )
+
+  ctx.status = 202
+  ctx.body = response
+
+  next()
+}
+
+export async function getSkuProductSpecificationTranslation(
+  ctx: Context,
+  next: () => Promise<unknown>
+) {
+  const {
+    clients: { catalogGraphQl },
+    state,
+  } = ctx
+
+  const { authorizationToken, translationData } = state
+
+  const response = await catalogGraphQl.getSkuProductSpecificationTranslation(
+    authorizationToken,
+    translationData as FieldQueryPayload
+  )
+
+  ctx.status = 202
+  ctx.body = response
+
+  next()
+}
+
+export async function getSpecificationValuesTranslation(
+  ctx: Context,
+  next: () => Promise<unknown>
+) {
+  const {
+    clients: { catalogGraphQl },
+    state,
+  } = ctx
+
+  const { authorizationToken, translationData } = state
+
+  const response = await catalogGraphQl.getSpecificationValuesTranslation(
+    authorizationToken,
+    translationData as FieldValuesQueryPayload
   )
 
   ctx.status = 202

--- a/node/middlewares/validateAuthToken.ts
+++ b/node/middlewares/validateAuthToken.ts
@@ -17,11 +17,9 @@ export async function validateAuthToken(
   )
 
   if (authorizationToken) {
-    const requestData: TranslatableData = await json(req)
-
     ctx.state.authorizationToken = authorizationToken
+    const requestData: unknown = await json(req)
     ctx.state.translationData = requestData
-
     await next()
   } else {
     ctx.status = 402

--- a/node/service.json
+++ b/node/service.json
@@ -37,6 +37,38 @@
     "categoryGroupTranslation": {
       "path": "/v0/catalog-translation/category-group",
       "public": true
+    },
+    "productSpecificationTranslation": {
+      "path": "/v0/catalog-translation/product-specification",
+      "public": true
+    },
+    "getCategoryTranslation": {
+      "path": "/v0/catalog-translation/category/fetch",
+      "public": true
+    },
+    "getBrandTranslation": {
+      "path": "/v0/catalog-translation/brand/fetch",
+      "public": true
+    },
+    "getProductTranslation": {
+      "path": "/v0/catalog-translation/product/fetch",
+      "public": true
+    },
+    "getSkuTranslation": {
+      "path": "/v0/catalog-translation/sku/fetch",
+      "public": true
+    },
+    "getSkuSpecificationTranslation": {
+      "path": "/v0/catalog-translation/sku-specification/fetch",
+      "public": true
+    },
+    "getSpecificationValuesTranslation": {
+      "path": "/v0/catalog-translation/specification-values/fetch",
+      "public": true
+    },
+    "getCategoryGroupTranslation": {
+      "path": "/v0/catalog-translation/category-group/fetch",
+      "public": true
     }
   },
   "events": {

--- a/node/typings/catalogGraphql.d.ts
+++ b/node/typings/catalogGraphql.d.ts
@@ -72,6 +72,31 @@ interface CategoryGroupData {
   locale: string
 }
 
+interface ProductSpecificationData {
+  srcLang: string // src locale
+  srcMessage: string  // src product specification
+  targetMessage: string // dst product specification
+  context: string // specification field ID
+}
+
+interface ProductSpecificationPayload {
+  args: {
+    to: string // dst locale
+    messages: ProductSpecificationData[] // translation data
+  }
+  locale: string
+}
+
+type TranslatableData =
+  | CategoryTranslationData
+  | BrandData
+  | ProductData
+  | SKUData
+  | SKUProductSpecificationData
+  | SpecificationValuesData
+  | CategoryGroupData
+  | ProductSpecificationPayload
+
 interface TranslationResponse {
   translateCategory: boolean
 }
@@ -87,11 +112,59 @@ interface BulkTranslationData {
   categoriesGroupsData: CategoryGroupData[]
 }
 
-type TranslatableData =
-  | CategoryTranslationData
-  | BrandData
-  | ProductData
-  | SKUData
-  | SKUProductSpecificationData
-  | SpecificationValuesData
-  | CategoryGroupData
+interface CategoryQueryPayload {
+  id: string
+  srcLocale: string
+  dstLocale: string
+}
+
+interface CategoryGroupQueryPayload {
+  id: string,
+  srcLocale: string
+  dstLocale: string
+}
+
+interface FieldQueryPayload {
+  id: string,
+  srcLocale: string
+  dstLocale: string
+}
+
+interface FieldValuesQueryPayload {
+  fieldId: string,
+  srcLocale: string
+  dstLocale: string
+}
+
+interface BrandQueryPayload {
+  id: string,
+  srcLocale: string
+  dstLocale: string
+}
+
+interface ProductQueryPayload {
+  identifier: {
+    field: string
+    value: any
+  },
+  srcLocale: string
+  dstLocale: string
+}
+
+interface SkuQueryPayload {
+  identifier: {
+    field: string
+    value: any
+  },
+  srcLocale: string
+  dstLocale: string
+}
+
+type TranslationQueryPayload =
+  | CategoryQueryPayload
+  | CategoryGroupQueryPayload
+  | FieldQueryPayload
+  | FieldValuesQueryPayload
+  | BrandQueryPayload
+  | ProductQueryPayload
+  | SkuQueryPayload


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adding the following features:

- translate product specifications of type "free text"
- retrieve translation for specific category and locale
- retrieve translation for specific category group and locale
- retrieve translation for specific specification field and locale
- retrieve translation for specific specification value and locale
- retrieve translation for specific brand and locale
- retrieve translation for specific product and locale
- retrieve translation for specific sku and locale

#### What problem is this solving?

No issues, just new features.

#### How to test it?

Testable at the following domain: https://lucablasi--itccwhirlpool.myvtex.com

#### Screenshots or example usage

![immagine](https://user-images.githubusercontent.com/76442030/195426819-4610b3d4-01f3-40c2-abba-469d4f9d393c.png)


#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X ] Requires change to documentation, which has been updated accordingly.
